### PR TITLE
issue 1 - converts final class to static class

### DIFF
--- a/src/Plugin/Block/LocalistEventsListBlock.php
+++ b/src/Plugin/Block/LocalistEventsListBlock.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   category = @Translation("Custom"),
  * )
  */
-final class LocalistEventsListBlock extends BlockBase implements ContainerFactoryPluginInterface {
+class LocalistEventsListBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
    * Constructs the plugin instance.
@@ -40,8 +40,8 @@ final class LocalistEventsListBlock extends BlockBase implements ContainerFactor
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
-    return new self(
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    return new static(
       $configuration,
       $plugin_id,
       $plugin_definition,


### PR DESCRIPTION
## Description
Teamwork Ticket(s): https://kanopi.teamwork.com/app/tasks/29458296

[Issue 1](https://github.com/kanopi/localist_events/issues/1) in the localist_events repo.

Converts LocalistEventsListBlock class from final class to static class.

## Steps to Validate
1. I tested this on Psych, and it didn't seem to cause any ill effects.

## Affected URL
n/a

